### PR TITLE
bump reqs llama_index==v0.9.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit
 streamlit-pills
-llama-index==0.9.4
+llama-index==0.9.7
 llama-hub==0.0.44
 # NOTE: this is due to a trivial dependency in the web tool, will refactor
 langchain==0.0.305


### PR DESCRIPTION
Some well-needed fixes for `CondensePlusContextChatEngine` introduced in v0.9.7 of llama-index