### PR TITLE
Add `--no-root` flag to installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is inspired by [GPTs](https://openai.com/blog/introducing-gpts), la
 Clone this project, go into the `rags` project folder. We recommend creating a virtual env for dependencies (`python3 -m venv .venv`).
 
 ```
-poetry install --with dev
+poetry install --with dev --no-root
 ```
 
 By default, we use OpenAI for both the builder agent as well as the generated RAG agent.


### PR DESCRIPTION
Closes #39. Since `rags` cannot be installed as a package, the installation command needs to include the `--no-root` flag, which this PR adds. 

When absent, running `poetry install --with dev` leads to the following error:

```sh
Writing lock file

Installing the current project: rags (0.0.2)
The current project could not be installed: No file/folder found for package rags
If you do not want to install the current project use --no-root
```